### PR TITLE
Scale data in place to avoid an extra full-array copy

### DIFF
--- a/pybv/io.py
+++ b/pybv/io.py
@@ -781,7 +781,9 @@ def _write_bveeg_file(eeg_fname, data, orientation, format, resolution, units): 
 
     # invert the resolution so that we know how much to scale our data
     scaling_factor = 1 / resolution
-    data = data * np.atleast_2d(scaling_factor).T
+    # `data` is a fresh array returned by `_scale_data_to_unit` (the caller's input is
+    # never mutated), so we can scale it in place to avoid allocating another full copy
+    data *= np.atleast_2d(scaling_factor).T
 
     # convert the data to required format
     if not _check_data_in_range(data, dtype):


### PR DESCRIPTION
(PR description and content created with the help of Claude)

## Summary

`_write_bveeg_file` applied the resolution scaling factor with `data = data * np.atleast_2d(scaling_factor).T`, allocating a new full-size array. The `data` being scaled is already a fresh array returned by `_scale_data_to_unit` (the caller's input is never mutated), so this multiply can be done in place with `*=`.

This removes one full-size `float64` allocation from the write path.

## Behavior

Unchanged. Same operands, same multiplication order — only the destination buffer differs (the existing array is reused instead of a new one being allocated). Output `.eeg`/`.vhdr`/`.vmrk` bytes are byte-for-byte identical, verified against `main` across `binary_float32`/`binary_int16` and several unit/resolution combinations.

## Impact

Measured on a 64×300k `float64` input (~154 MB), peak memory (`tracemalloc`):

| format | main | this PR |
| --- | --- | --- |
| binary_float32 | ~307 MB | ~230 MB |
| binary_int16 | ~307 MB | ~192 MB |

The full test suite (197 tests) passes unchanged.
